### PR TITLE
UI changes: delete on home page + added confirm popup on delete + other fixes

### DIFF
--- a/lib/screens/add_note_screen.dart
+++ b/lib/screens/add_note_screen.dart
@@ -72,17 +72,17 @@ class _AddNoteScreenState extends State<AddNoteScreen> {
     }
   }
 
-  _delete() {
-    DatabaseHelper.instance.deleteNote(widget.note!.id!);
-
-    Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (_) => HomeScreen(),
-        ));
-
-    widget.updateNoteList!();
-  }
+  // _delete() {
+  //   DatabaseHelper.instance.deleteNote(widget.note!.id!);
+  //
+  //   Navigator.pushReplacement(
+  //       context,
+  //       MaterialPageRoute(
+  //         builder: (_) => HomeScreen(),
+  //       ));
+  //
+  //   widget.updateNoteList!();
+  // }
 
   _submit() {
     if (_formKey.currentState!.validate()) {
@@ -127,33 +127,37 @@ class _AddNoteScreenState extends State<AddNoteScreen> {
             child: Container(
               padding: EdgeInsets.symmetric(
                 horizontal: 20.0,
-                vertical: 10.0,
+                vertical: 25.0,
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  GestureDetector(
-                    onTap: () {
-                      Navigator.pop(context);
-                    },
-                    child: Icon(
-                      Icons.arrow_back_ios_rounded,
-                      size: 25.0,
-                      color: Theme.of(context).primaryColor,
-                    ),
-                  ),
-                  SizedBox(
-                    height: 20,
-                  ),
-                  Center(
-                    child: Text(
-                      titleText,
-                      style: TextStyle(
-                        color: Colors.lightBlueAccent.shade200,
-                        fontSize: 20.0,
-                        fontWeight: FontWeight.bold,
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          Navigator.pop(context);
+                        },
+                        child: Icon(
+                          Icons.arrow_back_ios_rounded,
+                          size: 25.0,
+                          color: Theme.of(context).primaryColor,
+                        ),
                       ),
-                    ),
+                      Text(
+                        titleText,
+                        style: TextStyle(
+                          color: Colors.lightBlueAccent.shade200,
+                          fontSize: 20.0,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      SizedBox(
+                        width: 30,
+                      ),
+                    ],
                   ),
                   SizedBox(
                     height: 20.0,
@@ -268,28 +272,28 @@ class _AddNoteScreenState extends State<AddNoteScreen> {
                             ),
                           ),
                         ),
-                        widget.note != null
-                            ? Container(
-                                margin: EdgeInsets.symmetric(vertical: 10.0),
-                                height: 60.0,
-                                width: double.infinity,
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context).primaryColor,
-                                  borderRadius: BorderRadius.circular(40.0),
-                                ),
-                                child: ElevatedButton(
-                                  onPressed: _delete,
-                                  child: Text(
-                                    'delete'.toUpperCase(),
-                                    style: TextStyle(
-                                      fontSize: 18.0,
-                                      color: Colors.white,
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                                  ),
-                                ),
-                              )
-                            : SizedBox.shrink(),
+                        // widget.note != null
+                        //     ? Container(
+                        //         margin: EdgeInsets.symmetric(vertical: 10.0),
+                        //         height: 60.0,
+                        //         width: double.infinity,
+                        //         decoration: BoxDecoration(
+                        //           color: Theme.of(context).primaryColor,
+                        //           borderRadius: BorderRadius.circular(40.0),
+                        //         ),
+                        //         child: ElevatedButton(
+                        //           onPressed: _delete,
+                        //           child: Text(
+                        //             'delete'.toUpperCase(),
+                        //             style: TextStyle(
+                        //               fontSize: 18.0,
+                        //               color: Colors.white,
+                        //               fontWeight: FontWeight.bold,
+                        //             ),
+                        //           ),
+                        //         ),
+                        //       )
+                        //     : SizedBox.shrink(),
                       ],
                     ),
                   )

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -28,6 +28,12 @@ class _HomeScreenState extends State<HomeScreen> {
     _noteList = DatabaseHelper.instance.getNoteList();
   }
 
+  _delete(Note note) {
+    DatabaseHelper.instance.deleteNote(note.id!);
+    _updateNoteList();
+    setState((){ });
+  }
+
   Widget _buildTaskDesign(Note note, BuildContext context) {
     return Padding(
       padding: EdgeInsets.symmetric(
@@ -56,16 +62,31 @@ class _HomeScreenState extends State<HomeScreen> {
                   : TextDecoration.lineThrough,
             ),
           ),
-          trailing: Checkbox(
-            onChanged: (value) {
-              note.status = value! ? 1 : 0;
-              DatabaseHelper.instance.updateNote(note);
-              _updateNoteList();
-              Navigator.pushReplacement(
-                  context, MaterialPageRoute(builder: (_) => HomeScreen()));
-            },
-            activeColor: Theme.of(context).primaryColor,
-            value: note.status == 1 ? true : false,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              GestureDetector(
+                onTap: () {
+                  showConfirmDialog(note);
+                },
+                child: Icon(
+                  Icons.delete,
+                  size: 25.0,
+                  color: Colors.red,
+                ),
+              ),
+              Checkbox(
+                onChanged: (value) {
+                  note.status = value! ? 1 : 0;
+                  DatabaseHelper.instance.updateNote(note);
+                  _updateNoteList();
+                  Navigator.pushReplacement(
+                      context, MaterialPageRoute(builder: (_) => HomeScreen()));
+                },
+                activeColor: Theme.of(context).primaryColor,
+                value: note.status == 1 ? true : false,
+              ),
+            ],
           ),
           onTap: () {
             Navigator.push(
@@ -110,16 +131,15 @@ class _HomeScreenState extends State<HomeScreen> {
             if (!snapshot.hasData) {
               return Center(
                 // child: CircularProgressIndicator(),
-                child : Column(
+                child: Column(
                   children: [
                     Container(
                       width: 120,
                       height: 300,
                       decoration: const BoxDecoration(
                         image: DecorationImage(
-                          image: AssetImage("images/waiting.png"),
-                          fit: BoxFit.cover
-                        ),
+                            image: AssetImage("images/waiting.png"),
+                            fit: BoxFit.cover),
                       ),
                     ),
                     Text(
@@ -159,14 +179,23 @@ class _HomeScreenState extends State<HomeScreen> {
                         SizedBox(
                           height: 5.0,
                         ),
-                        Text(
-                          '$completeNoteCount of ${snapshot.data.length} task is complete',
-                          style: TextStyle(
-                            color: Colors.lightBlueAccent.shade100,
-                            fontSize: 14.0,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
+                        completeNoteCount == 0 && snapshot.data.length == 0
+                            ? Text(
+                                'Hey! you did not add any task yet',
+                                style: TextStyle(
+                                  color: Colors.lightBlueAccent.shade100,
+                                  fontSize: 14.0,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              )
+                            : Text(
+                                '$completeNoteCount of ${snapshot.data.length} task is complete',
+                                style: TextStyle(
+                                  color: Colors.lightBlueAccent.shade100,
+                                  fontSize: 14.0,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
                       ],
                     ),
                   );
@@ -175,6 +204,69 @@ class _HomeScreenState extends State<HomeScreen> {
               },
             );
           }),
+    );
+  }
+
+  showConfirmDialog(Note note) {
+    return showDialog(
+      context: context,
+      builder: (context) {
+        return Dialog(
+            shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            elevation: 16,
+            child: Container(
+              padding: const EdgeInsets.fromLTRB(10, 30, 10, 30),
+              height: 150.0,
+              width: MediaQuery.of(context).size.width * 0.9,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  const Text(
+                    'Are you sure you want to delete?',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black,
+                        fontSize: 14.0),
+                  ),
+                  const SizedBox(height: 15.0),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      RaisedButton(
+                        color: Theme.of(context).primaryColor,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(25.0),
+                        ),
+                        onPressed: () {
+                          _delete(note);
+                          Navigator.pop(context);
+                        },
+                        padding: const EdgeInsets.all(12),
+                        child: const Text('Yes',
+                            style:
+                            TextStyle(color: Colors.white, fontSize: 14)),
+                      ),
+                      RaisedButton(
+                        color: Theme.of(context).primaryColor,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(25.0),
+                        ),
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                        padding: const EdgeInsets.all(12),
+                        child: const Text('No',
+                            style:
+                            TextStyle(color: Colors.white, fontSize: 14)),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ));
+      },
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -94,21 +94,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -176,7 +183,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sqflite:
     dependency: "direct main"
     description:
@@ -232,21 +239,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:
@@ -262,5 +262,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.0.0"


### PR DESCRIPTION
- Move the delete functionality from outside to the homepage tile
- Confirming before deleting the note by using popup
- Text change when there are no notes on screen (for first-time users or when all notes are deleted)
- Align the back button on add note screen with the header text

Refer below screenshot, having updated UI which has the delete icon on tile and confirm popup

![Updated UI Screenshot](https://user-images.githubusercontent.com/9162827/197334958-b53257ad-9c1e-40e0-93d5-082ed0303cc5.png) 
